### PR TITLE
Make dictionary loader compile on mac as well as linux

### DIFF
--- a/babble_unix.go
+++ b/babble_unix.go
@@ -1,3 +1,5 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
 package babble
 
 import (


### PR DESCRIPTION
We used the same list of operating systems that the go `filepath` library
designates as 'unix'.
