### PR TITLE
Fix "missing dot in first path element" error

### DIFF
--- a/babble_test.go
+++ b/babble_test.go
@@ -1,7 +1,7 @@
 package babble_test
 
 import (
-	. "babble"
+	. "github.com/tjarratt/babble"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
In go1.13, toolchain commands like "go mod tidy" will fail if babble is a dependency of the module.

Example error:

<path of my module> imports
        github.com/tjarratt/babble tested by
        github.com/tjarratt/babble.test imports
        babble: malformed module path "babble": missing dot in first path element